### PR TITLE
Bypass virtual keypresses and allow separate press and release events

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ LUA_PKG_NAME ?= lua
 LIBSPNAV = ./libspnav-0.2.2/
 
 CFLAGS = -std=gnu99 -pedantic -Wall -g -I$(LIBSPNAV) $(shell pkg-config --cflags $(LUA_PKG_NAME))
-LDFLAGS = -lrt -L$(LIBSPNAV) -lspnav -lX11 $(shell pkg-config --libs lua)
+LDFLAGS = -lrt -L$(LIBSPNAV) -lspnav -lXtst -lX11 $(shell pkg-config --libs lua)
 
 .PHONY: all
 all: spnavkbd

--- a/spnavkbd.lua
+++ b/spnavkbd.lua
@@ -128,12 +128,36 @@ function motion_event(x, y, z, rx, ry, rz)
     end
 end
 
+
+-- Available actions
+-- send_keyev -- press and immediate release of key
+-- press_keyev -- press of key
+-- release_keyev -- release of key
+
+SHIFT = 50
+CTRL = 37
+ALT = 64
+
 function button_event(action, bnum)
     if action == "press" then
         if bnum == 0 then
             send_keyev(9, 0)
-        else
+        elseif bnum == 1 then
             send_keyev(23, 0)
+        elseif bnum == 6 then
+            press_keyev(SHIFT, 0)
+        elseif bnum == 7 then
+            press_keyev(CTRL, 0)
+        elseif bnum == 8 then
+            press_keyev(ALT, 0)
+        end
+    else
+        if bnum == 6 then
+            release_keyev(SHIFT, 0)
+        elseif bnum == 7 then
+            release_keyev(CTRL, 0)
+        elseif bnum == 8 then
+            release_keyev(ALT, 0)
         end
     end
 end


### PR DESCRIPTION
I added the ability to send press and release events separately. I noticed that the old xlib function for sending key events wasn't working in most applications, so I switched to using `xtest` functions which pretend to be sent from a real keyboard.